### PR TITLE
個々の Page にそれぞれもつ

### DIFF
--- a/src/layouts/DefaultLayout/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout/DefaultLayout.tsx
@@ -4,10 +4,19 @@ import { Link } from "react-router-dom";
 
 import classes from "./index.module.css";
 
-type Props = Readonly<PropsWithChildren<unknown>>;
+export type Breadcrumbs = {
+  title: string;
+  to?: string;
+}[];
+
+type Props = Readonly<
+  PropsWithChildren<{
+    breadcrumbs: Breadcrumbs;
+  }>
+>;
 
 export const DefaultLayout = (props: Props): JSX.Element => {
-  const { children } = props;
+  const { breadcrumbs, children } = props;
 
   return (
     <div className={classes.root}>
@@ -24,6 +33,19 @@ export const DefaultLayout = (props: Props): JSX.Element => {
           </li>
         </ul>
       </nav>
+
+      <nav>
+        <ol className={classes.breadcrumbs}>
+          {breadcrumbs.map((item, i) => {
+            return (
+              <li key={i}>
+                {item.to ? <Link to={item.to}>{item.title}</Link> : item.title}
+              </li>
+            );
+          })}
+        </ol>
+      </nav>
+
       <main>{children}</main>
     </div>
   );

--- a/src/layouts/DefaultLayout/index.ts
+++ b/src/layouts/DefaultLayout/index.ts
@@ -1,3 +1,4 @@
-import { DefaultLayout } from "./DefaultLayout";
+import { DefaultLayout, Breadcrumbs } from "./DefaultLayout";
 
 export { DefaultLayout };
+export type { Breadcrumbs };

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,8 +1,10 @@
-import { DefaultLayout } from "../../layouts";
+import { Breadcrumbs, DefaultLayout } from "../../layouts";
+
+const breadcrumbs: Breadcrumbs = [{ title: "ホーム" }];
 
 export const Home = (): JSX.Element => {
   return (
-    <DefaultLayout>
+    <DefaultLayout breadcrumbs={breadcrumbs}>
       <h2>ホーム</h2>
 
       <p>Home</p>

--- a/src/pages/User/User.tsx
+++ b/src/pages/User/User.tsx
@@ -1,8 +1,10 @@
+import { useMemo } from "react";
+
 import useAspidaSWR from "@aspida/swr";
 import { useParams } from "react-router-dom";
 
 import { client } from "../../api/client";
-import { DefaultLayout } from "../../layouts";
+import { Breadcrumbs, DefaultLayout } from "../../layouts";
 import { assertIsDefined } from "../../utils/assertIsDefined";
 
 export const User = (): JSX.Element => {
@@ -11,8 +13,19 @@ export const User = (): JSX.Element => {
 
   const { data } = useAspidaSWR(client.users._id(userId), "get");
 
+  const breadcrumbs = useMemo<Breadcrumbs>(() => {
+    const breadcrumbs: Breadcrumbs = [
+      { title: "ホーム", to: "/" },
+      { title: "ユーザ一覧", to: "/users" },
+    ];
+    if (data) {
+      breadcrumbs.push({ title: data.body.name });
+    }
+    return breadcrumbs;
+  }, [data]);
+
   return (
-    <DefaultLayout>
+    <DefaultLayout breadcrumbs={breadcrumbs}>
       <h2>ユーザ</h2>
 
       {data ? <p>User: {data.body.name}</p> : <p>Loading...</p>}

--- a/src/pages/Users/Users.tsx
+++ b/src/pages/Users/Users.tsx
@@ -2,13 +2,18 @@ import useAspidaSWR from "@aspida/swr";
 import { Link } from "react-router-dom";
 
 import { client } from "../../api/client";
-import { DefaultLayout } from "../../layouts";
+import { Breadcrumbs, DefaultLayout } from "../../layouts";
+
+const breadcrumbs: Breadcrumbs = [
+  { title: "ホーム", to: "/" },
+  { title: "ユーザ一覧" },
+];
 
 export const Users = (): JSX.Element => {
   const { data } = useAspidaSWR(client.users, "get");
 
   return (
-    <DefaultLayout>
+    <DefaultLayout breadcrumbs={breadcrumbs}>
       <h2>ユーザ一覧</h2>
 
       {data ? (


### PR DESCRIPTION
## 概要

- `<DefaultLayout />` に breadcrumbs の Props を追加
- それぞれのページにパンくずをもたせるため、Nest Routesを廃止