### PR TITLE
パンくずリストが別の `<Routes />` をもつ

### DIFF
--- a/src/layouts/DefaultLayout/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout/DefaultLayout.tsx
@@ -1,6 +1,7 @@
-import { Link, Outlet } from "react-router-dom";
+import { Link, Outlet, Route, Routes } from "react-router-dom";
 
 import classes from "./index.module.css";
+import { Username } from "./Username";
 
 export const DefaultLayout = (): JSX.Element => {
   return (
@@ -17,6 +18,46 @@ export const DefaultLayout = (): JSX.Element => {
             <Link to="/users">Users</Link>
           </li>
         </ul>
+      </nav>
+      <nav>
+        <ol className={classes.breadcrumbs}>
+          <Routes>
+            <Route path="/" element={<li>ホーム</li>} />
+            <Route
+              path="/*"
+              element={
+                <>
+                  <li>
+                    <Link to="/">ホーム</Link>
+                  </li>
+                  <Outlet />
+                </>
+              }
+            >
+              <Route path="users" element={<li>ユーザ一覧</li>} />
+              <Route
+                path="/*"
+                element={
+                  <>
+                    <li>
+                      <Link to="/users">ユーザ一覧</Link>
+                    </li>
+                    <Outlet />
+                  </>
+                }
+              >
+                <Route
+                  path="users/:userId"
+                  element={
+                    <li>
+                      <Username />
+                    </li>
+                  }
+                />
+              </Route>
+            </Route>
+          </Routes>
+        </ol>
       </nav>
       <main>
         <Outlet />

--- a/src/layouts/DefaultLayout/Username.tsx
+++ b/src/layouts/DefaultLayout/Username.tsx
@@ -1,0 +1,14 @@
+import useAspidaSWR from "@aspida/swr";
+import { useParams } from "react-router-dom";
+
+import { client } from "../../api/client";
+import { assertIsDefined } from "../../utils/assertIsDefined";
+
+export const Username = () => {
+  const { userId } = useParams();
+  assertIsDefined(userId);
+
+  const { data } = useAspidaSWR(client.users._id(userId), "get");
+
+  return <>{data ? data.body.name : "-"}</>;
+};


### PR DESCRIPTION
## 概要

- パンくずリストが Page とは別の `<Routes />` をもち階層を管理する