### PR TITLE
use-react-router-breadcrumbs を使ってパンくずを生成

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-router-dom": "6.2.1",
-    "swr": "1.1.2"
+    "swr": "1.1.2",
+    "use-react-router-breadcrumbs": "3.0.2"
   },
   "devDependencies": {
     "@babel/core": "7.16.12",

--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -1,16 +1,36 @@
-import { Routes, Route } from "react-router-dom";
+import { useRoutes } from "react-router-dom";
+import useBreadcrumbs from "use-react-router-breadcrumbs";
 
+import { BreadcrumbsUser } from "./components/Breadcrumbs";
 import { DefaultLayout } from "./layouts";
 import { Home, User, Users } from "./pages";
 
+export const routes: Parameters<typeof useBreadcrumbs>[0] = [
+  {
+    path: "/",
+    element: <DefaultLayout />,
+    children: [
+      {
+        index: true,
+        element: <Home />,
+        breadcrumb: "ホーム",
+      },
+      {
+        path: "/users",
+        element: <Users />,
+        breadcrumb: "ユーザ一覧",
+      },
+      {
+        path: "/users/:userId",
+        element: <User />,
+        breadcrumb: BreadcrumbsUser,
+      },
+    ],
+  },
+];
+
 export const AppRoutes = (): JSX.Element => {
-  return (
-    <Routes>
-      <Route path="/" element={<DefaultLayout />}>
-        <Route index element={<Home />} />
-        <Route path="/users" element={<Users />} />
-        <Route path="/users/:userId" element={<User />} />
-      </Route>
-    </Routes>
-  );
+  const element = useRoutes(routes);
+
+  return <>{element}</>;
 };

--- a/src/components/Breadcrumbs/BreadcrumbsUser.tsx
+++ b/src/components/Breadcrumbs/BreadcrumbsUser.tsx
@@ -1,0 +1,14 @@
+import useAspidaSWR from "@aspida/swr";
+import { useParams } from "react-router-dom";
+
+import { client } from "../../api/client";
+import { assertIsDefined } from "../../utils/assertIsDefined";
+
+export const BreadcrumbsUser = () => {
+  const { userId } = useParams();
+  assertIsDefined(userId);
+
+  const { data } = useAspidaSWR(client.users._id(userId), "get");
+
+  return <>{data ? data.body.name : "-"}</>;
+};

--- a/src/components/Breadcrumbs/index.ts
+++ b/src/components/Breadcrumbs/index.ts
@@ -1,0 +1,3 @@
+import { BreadcrumbsUser } from "./BreadcrumbsUser";
+
+export { BreadcrumbsUser };

--- a/src/layouts/DefaultLayout/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout/DefaultLayout.tsx
@@ -1,8 +1,12 @@
 import { Link, Outlet } from "react-router-dom";
+import useBreadcrumbs from "use-react-router-breadcrumbs";
 
+import { routes } from "../../AppRoutes";
 import classes from "./index.module.css";
 
 export const DefaultLayout = (): JSX.Element => {
+  const breadcrumbs = useBreadcrumbs(routes);
+
   return (
     <div className={classes.root}>
       <header>
@@ -17,6 +21,13 @@ export const DefaultLayout = (): JSX.Element => {
             <Link to="/users">Users</Link>
           </li>
         </ul>
+      </nav>
+      <nav>
+        <ol>
+          {breadcrumbs.map(({ key, breadcrumb }) => (
+            <li key={key}>{breadcrumb}</li>
+          ))}
+        </ol>
       </nav>
       <main>
         <Outlet />

--- a/yarn.lock
+++ b/yarn.lock
@@ -12523,6 +12523,11 @@ use-latest@^1.0.0:
   dependencies:
     use-isomorphic-layout-effect "^1.0.0"
 
+use-react-router-breadcrumbs@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/use-react-router-breadcrumbs/-/use-react-router-breadcrumbs-3.0.2.tgz#4e43feee6227de43639a379644f9e7b92824e45e"
+  integrity sha512-tMIosbfVV0pH+i98k/9HDXXhU8eExb9s11FMv8zruM/4MYJ7M6rVwNojVgTqRP3Z9h62TBZUO2842vVT1wpqRg==
+
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"


### PR DESCRIPTION
## 概要

- use-react-router-breadcrumbs を使ってパンくずを生成
- react-router は useRoutes を使うことで、use-react-router-breadcrumbs で使用するルート設定と共通化