### PR TITLE
通常のルートとパンくずリストを同じ関数で生成させ、それぞれで useRoutes() を使う

### DIFF
--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -1,16 +1,10 @@
-import { Routes, Route } from "react-router-dom";
+import { useRoutes } from "react-router-dom";
 
-import { DefaultLayout } from "./layouts";
-import { Home, User, Users } from "./pages";
+import { createRoutes } from "./utils/createRoutes";
 
 export const AppRoutes = (): JSX.Element => {
-  return (
-    <Routes>
-      <Route path="/" element={<DefaultLayout />}>
-        <Route index element={<Home />} />
-        <Route path="/users" element={<Users />} />
-        <Route path="/users/:userId" element={<User />} />
-      </Route>
-    </Routes>
-  );
+  const routes = createRoutes();
+  const element = useRoutes(routes);
+
+  return <>{element}</>;
 };

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,0 +1,27 @@
+import { NavLink, Outlet, useResolvedPath } from "react-router-dom";
+
+import { useIsActive } from "../../hooks/useIsActive";
+
+type Props = {
+  text: string;
+};
+
+export const Breadcrumbs = (props: Props) => {
+  const { text } = props;
+
+  const resolvedLocation = useResolvedPath("");
+  const isActive = useIsActive();
+
+  return (
+    <>
+      {isActive ? (
+        <li>{text}</li>
+      ) : (
+        <li>
+          <NavLink to={resolvedLocation.pathname}>{text}</NavLink>
+        </li>
+      )}
+      <Outlet />
+    </>
+  );
+};

--- a/src/components/Breadcrumbs/BreadcrumbsUser.tsx
+++ b/src/components/Breadcrumbs/BreadcrumbsUser.tsx
@@ -1,0 +1,15 @@
+import useAspidaSWR from "@aspida/swr";
+import { useParams } from "react-router-dom";
+
+import { client } from "../../api/client";
+import { assertIsDefined } from "../../utils/assertIsDefined";
+import { Breadcrumbs } from "./Breadcrumbs";
+
+export const BreadcrumbsUser = () => {
+  const { userId } = useParams();
+  assertIsDefined(userId);
+
+  const { data } = useAspidaSWR(client.users._id(userId), "get");
+
+  return <Breadcrumbs text={data ? data.body.name : "-"} />;
+};

--- a/src/components/Breadcrumbs/index.ts
+++ b/src/components/Breadcrumbs/index.ts
@@ -1,0 +1,4 @@
+import { Breadcrumbs } from "./Breadcrumbs";
+import { BreadcrumbsUser } from "./BreadcrumbsUser";
+
+export { Breadcrumbs, BreadcrumbsUser };

--- a/src/hooks/useIsActive.ts
+++ b/src/hooks/useIsActive.ts
@@ -1,0 +1,14 @@
+import { useMemo } from "react";
+
+import { useLocation, useResolvedPath } from "react-router-dom";
+
+export const useIsActive = () => {
+  const location = useLocation();
+  const resolvedLocation = useResolvedPath("");
+
+  const isActive = useMemo(() => {
+    return location.pathname === resolvedLocation.pathname;
+  }, [location.pathname, resolvedLocation.pathname]);
+
+  return isActive;
+};

--- a/src/layouts/DefaultLayout/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout/DefaultLayout.tsx
@@ -1,8 +1,12 @@
-import { Link, Outlet } from "react-router-dom";
+import { Link, Outlet, useRoutes } from "react-router-dom";
 
+import { createRoutes } from "../../utils/createRoutes";
 import classes from "./index.module.css";
 
 export const DefaultLayout = (): JSX.Element => {
+  const routes = createRoutes(false);
+  const breadcrumbs = useRoutes(routes);
+
   return (
     <div className={classes.root}>
       <header>
@@ -17,6 +21,9 @@ export const DefaultLayout = (): JSX.Element => {
             <Link to="/users">Users</Link>
           </li>
         </ul>
+      </nav>
+      <nav>
+        <ol>{breadcrumbs}</ol>
       </nav>
       <main>
         <Outlet />

--- a/src/pages/Users/Users.tsx
+++ b/src/pages/Users/Users.tsx
@@ -1,10 +1,16 @@
 import useAspidaSWR from "@aspida/swr";
-import { Link } from "react-router-dom";
+import { Link, Outlet } from "react-router-dom";
 
 import { client } from "../../api/client";
+import { useIsActive } from "../../hooks/useIsActive";
 
 export const Users = (): JSX.Element => {
   const { data } = useAspidaSWR(client.users, "get");
+  const isActive = useIsActive();
+
+  if (!isActive) {
+    return <Outlet />;
+  }
 
   return (
     <div>

--- a/src/utils/createRoutes.tsx
+++ b/src/utils/createRoutes.tsx
@@ -1,0 +1,30 @@
+import { Outlet, useRoutes } from "react-router-dom";
+
+import { Breadcrumbs, BreadcrumbsUser } from "../components/Breadcrumbs";
+import { DefaultLayout } from "../layouts";
+import { Home, User, Users } from "../pages";
+
+export const createRoutes = (
+  isPage = true
+): Parameters<typeof useRoutes>[0] => [
+  {
+    path: "*",
+    element: isPage ? <DefaultLayout /> : <Breadcrumbs text="ホーム" />,
+    children: [
+      {
+        index: true,
+        element: isPage ? <Home /> : <Outlet />,
+      },
+      {
+        path: "users",
+        element: isPage ? <Users /> : <Breadcrumbs text="ユーザ一覧" />,
+        children: [
+          {
+            path: ":userId",
+            element: isPage ? <User /> : <BreadcrumbsUser />,
+          },
+        ],
+      },
+    ],
+  },
+];


### PR DESCRIPTION
## 概要

- 通常のルートとパンくずリストを `createRoutes()` で生成
  - 参考: https://github.com/remix-run/react-router/issues/7273#issuecomment-626814462
- パンくずリストで `<Outlet />` が必要になるが、Page側では不要になるケースを忘れるとコンテンツが切り替わらない状態になるので注意が必要
  - 上記を確認するためのカスタムフック `useIsActive()` を作成しています